### PR TITLE
what does Z stand for?

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,17 @@
+# zlib license <br> [&copy; s9a](https://github.com/s9a)
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
[among lizenzes](https://choosealicense.com/appendix/), [<b>zlib license</b>](https://choosealicense.com/licenses/zlib/) [pub'd on <time datetime="1995-04-15">tax day 1995</a>](https://en.wikipedia.org/wiki/Zlib_License) seem reazonable here, becauze [<b>it'z an archive</b> from during <time datetime="2020">lockdown</time>](https://s9a.page/lockdown), i did have a quick cruzh on [artistic license](https://choosealicense.com/licenses/artistic-2.0/) for this but they were too long to commit, later i got in a [love-hate](https://github.com/webmural/lovehate) [relationship](https://github.com/s9a/post) with [post****** license](https://choosealicense.com/licenses/postgresql/) but really who will care when [the future](https://s9a.page) is `<0.8` secondz away, tapped in, for anyone with a moment to tell me what the `Z` in `Zlib` standz for? i would love to know, just curiouzZ, [**stay free**](https://github.com/s9a/free)